### PR TITLE
Add Support for Bootboot

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -f "$1/Gemfile" ]; then
+if [ -f "$1/Gemfile" ] || [ -f "$1/gems.rb" ]; then
   echo "Ruby"
   exit 0
 else

--- a/bin/support/ruby_test
+++ b/bin/support/ruby_test
@@ -41,7 +41,7 @@ LanguagePack::ShellHelpers.user_env_hash["PATH"] = "#{build_dir}/bin:#{ENV["PATH
 LanguagePack::ShellHelpers.user_env_hash["GEM_PATH"] = LanguagePack::Ruby.slug_vendor_base
 
 bundler = LanguagePack::Helpers::BundlerWrapper.new(
-  gemfile_path: "#{build_dir}/Gemfile"
+  build_dir: build_dir
 )
 # load bundler
 bundler.install

--- a/changelogs/v208/fix-bundle-config-check.md
+++ b/changelogs/v208/fix-bundle-config-check.md
@@ -1,0 +1,3 @@
+## Check for .bundle/config before running bundle
+
+If there are any user set bundle environment variables (like gem credentials), these will be persisted in .bundle/config automatically, so we now check for .bundle/config before any bundle commands have been to avoid reporting a false positive.

--- a/changelogs/v208/gems.rb.md
+++ b/changelogs/v208/gems.rb.md
@@ -1,0 +1,2 @@
+## Add support for gems.rb
+Adds support for gems.rb and gems.locked (instead of Gemfile and Gemfile.lock).

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -40,6 +40,16 @@ class LanguagePack::Base
     end
   end
 
+  def bundler
+    self.class.bundler
+  end
+
+  def self.bundler
+    @@bundler ||= LanguagePack::Helpers::BundlerWrapper.new.tap { |b|
+      topic "Using #{b.gemfile} and #{b.lockfile} for Bundler"
+    }.install
+  end
+
   def instrument(*args, &block)
     self.class.instrument(*args, &block)
   end

--- a/lib/language_pack/disable_deploys.rb
+++ b/lib/language_pack/disable_deploys.rb
@@ -3,7 +3,7 @@ require "language_pack/base"
 
 class LanguagePack::DisableDeploys < LanguagePack::Base
   def self.use?
-    File.exist?("Gemfile")
+    File.exist?(bundler.gemfile)
   end
 
   def name

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'pathname'
 require 'language_pack/fetcher'
 
 # This class is responsible for installing and maintaining a
@@ -41,21 +42,31 @@ class LanguagePack::Helpers::BundlerWrapper
   BUNDLED_WITH_REGEX = /^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m
 
   class GemfileParseError < BuildpackError
-    def initialize(error)
-      msg = String.new("There was an error parsing your Gemfile, we cannot continue\n")
+    def initialize(error, gemfile)
+      msg = String.new("There was an error parsing your #{gemfile}, we cannot continue\n")
       msg << error
       super msg
     end
   end
 
+  class DuplicateGemfileError < BuildpackError
+    def initialize
+      super <<~ERR
+        You have both a Gemfile and a gems.rb in your repository. This is not
+        currently supported. You must remove one or the other for the buildpack
+        to correctly determine the Bundler version to use.
+      ERR
+    end
+  end
+
   class UnsupportedBundlerVersion < BuildpackError
-    def initialize(version_hash, major)
-      msg = String.new("Your Gemfile.lock indicates you need bundler `#{major}.x`\n")
+    def initialize(version_hash, major, lockfile)
+      msg = String.new("Your #{lockfile} indicates you need bundler `#{major}.x`\n")
       msg << "which is not currently supported. You can deploy with bundler version:\n"
       version_hash.keys.each do |v|
         msg << "  - `#{v}.x`\n"
       end
-      msg << "\nTo use another version of bundler, update your `Gemfile.lock` to point\n"
+      msg << "\nTo use another version of bundler, update your `#{lockfile}` to point\n"
       msg << "to a supported version. For example:\n"
       msg << "\n"
       msg << "```\n"
@@ -69,20 +80,56 @@ class LanguagePack::Helpers::BundlerWrapper
   attr_reader :bundler_path
 
   def initialize(options = {})
-    @bundler_tmp          = Pathname.new(Dir.mktmpdir)
-    @fetcher              = options[:fetcher]      || LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL) # coupling
-    @gemfile_path         = options[:gemfile_path] || Pathname.new("./Gemfile")
-    @gemfile_lock_path    = Pathname.new("#{@gemfile_path}.lock")
+    @bundler_tmp  = Pathname.new(Dir.mktmpdir)
+    @fetcher      = options[:fetcher] || LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL) # coupling
+    @build_dir    = options[:build_dir] ? Pathname(options[:build_dir]) : Pathname.new('.')
+
     detect_bundler_version_and_dir_name!
 
-    @bundler_path         = options[:bundler_path] || @bundler_tmp.join(dir_name)
-    @bundler_tar          = options[:bundler_tar]  || "bundler/#{dir_name}.tgz"
+    @bundler_path = options[:bundler_path] ? Pathname(options[:bundler_path]) : @bundler_tmp.join(dir_name)
+    @bundler_tar          = options[:bundler_tar] || "bundler/#{dir_name}.tgz"
     @orig_bundle_gemfile  = ENV['BUNDLE_GEMFILE']
     @path                 = Pathname.new("#{@bundler_path}/gems/#{dir_name}/lib")
   end
 
+  # This method is used before bundler is installed since we need to determine
+  # the lockfile path in order to determine the version of bundler to install.
+  # However, we can't know which gemfile/lockfile to prefer without Bundler
+  # being loaded since the version of Bundler being used determines the
+  # precedence of Gemfile vs gems.rb if they both exist. The simplest way to
+  # deterministically read the correct bundler version from the correct gemfile
+  # is to disallow having both of them.
+  def gemfile_path
+    @gemfile_path ||= begin
+      gems_rb_path = @build_dir.join("gems.rb")
+      gemfile_path = @build_dir.join("Gemfile")
+      if gems_rb_path.exist?
+        raise DuplicateGemfileError if gemfile_path.exist?
+        gems_rb_path
+      else
+        gemfile_path
+      end
+    end
+  end
+
+  def gemfile
+    @gemfile ||= gemfile_path.basename.to_s
+  end
+
+  def lockfile_path
+    @lockfile_path ||= if gemfile == "gems.rb"
+      @build_dir.join("gems.locked")
+    else
+      @build_dir.join("Gemfile.lock")
+    end
+  end
+
+  def lockfile
+    @lockfile ||= lockfile_path.basename.to_s
+  end
+
   def install
-    ENV['BUNDLE_GEMFILE'] = @gemfile_path.to_s
+    ENV['BUNDLE_GEMFILE'] = gemfile_path.to_s
 
     fetch_bundler
     $LOAD_PATH << @path
@@ -109,7 +156,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   # detects whether the Gemfile.lock contains the Windows platform
   # @return [Boolean] true if the Gemfile.lock was created on Windows
-  def windows_gemfile_lock?
+  def windows_lockfile?
     platforms.detect do |platform|
       /mingw|mswin/.match(platform.os) if platform.is_a?(Gem::Platform)
     end
@@ -148,7 +195,7 @@ class LanguagePack::Helpers::BundlerWrapper
       output  = run_stdout(command, user_env: true, env: env).strip.lines.last
 
       # If there's a gem in the Gemfile (i.e. syntax error) emit error
-      raise GemfileParseError.new(run("bundle check", user_env: true, env: env)) unless $?.success?
+      raise GemfileParseError.new(run("bundle check", user_env: true, env: env), gemfile) unless $?.success?
       if output.match(/No ruby version specified/)
         ""
       else
@@ -158,7 +205,7 @@ class LanguagePack::Helpers::BundlerWrapper
   end
 
   def lockfile_parser
-    @lockfile_parser ||= parse_gemfile_lock
+    @lockfile_parser ||= parse_lockfile
   end
 
   private
@@ -177,16 +224,16 @@ class LanguagePack::Helpers::BundlerWrapper
     end
   end
 
-  def parse_gemfile_lock
-    instrument 'parse_bundle' do
-      gemfile_contents = File.read(@gemfile_lock_path)
-      Bundler::LockfileParser.new(gemfile_contents)
+  def parse_lockfile
+    instrument 'parse_lockfile' do
+      lockfile_contents = File.read(lockfile_path)
+      Bundler::LockfileParser.new(lockfile_contents)
     end
   end
 
   def major_bundler_version
     # https://rubular.com/r/jt9yj0aY7fU3hD
-    bundler_version_match = @gemfile_lock_path.read(mode: "rt").match(BUNDLED_WITH_REGEX)
+    bundler_version_match = lockfile_path.read(mode: "rt").match(BUNDLED_WITH_REGEX)
 
     if bundler_version_match
       bundler_version_match[:major]
@@ -203,14 +250,14 @@ class LanguagePack::Helpers::BundlerWrapper
     if BLESSED_BUNDLER_VERSIONS.key?(major)
       @version = BLESSED_BUNDLER_VERSIONS[major]
     else
-      raise UnsupportedBundlerVersion.new(BLESSED_BUNDLER_VERSIONS, major)
+      raise UnsupportedBundlerVersion.new(BLESSED_BUNDLER_VERSIONS, major, lockfile)
     end
   end
 
   def bundler_version_escape_valve!
-    topic("Removing BUNDLED WITH version in the Gemfile.lock")
-    contents = File.read("Gemfile.lock")
-    File.open("Gemfile.lock", "w") do |f|
+    topic("Removing BUNDLED WITH version in the #{lockfile}")
+    contents = File.read(lockfile)
+    File.open(lockfile, "w") do |f|
       f.write contents.sub(/^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m, '')
     end
   end

--- a/lib/language_pack/helpers/rake_runner.rb
+++ b/lib/language_pack/helpers/rake_runner.rb
@@ -65,10 +65,11 @@ class LanguagePack::Helpers::RakeRunner
     end
   end
 
-  def initialize(has_rake_gem = true)
+  def initialize(has_rake_gem = true, gemfile = "Gemfile")
     @has_rake_gem = has_rake_gem
+    @gemfile      = gemfile
     if !has_rake_installed?
-      @rake_tasks    = ""
+      @rake_tasks        = ""
       @rakefile_can_load = false
     end
   end
@@ -101,7 +102,7 @@ class LanguagePack::Helpers::RakeRunner
     if cannot_load_rakefile?
       msg =  "Could not detect rake tasks\n"
       msg << "ensure you can run `$ bundle exec rake -P` against your app\n"
-      msg << "and using the production group of your Gemfile.\n"
+      msg << "and using the production group of your #{@gemfile}.\n"
       msg << out
       raise CannotLoadRakefileError, msg if raise_on_fail
       puts msg
@@ -138,6 +139,6 @@ class LanguagePack::Helpers::RakeRunner
 private
 
   def has_rakefile?
-    %W{ Rakefile rakefile  rakefile.rb Rakefile.rb}.detect {|file| File.exist?(file) }
+    %W{Rakefile rakefile rakefile.rb Rakefile.rb}.detect {|file| File.exist?(file) }
   end
 end

--- a/lib/language_pack/no_lockfile.rb
+++ b/lib/language_pack/no_lockfile.rb
@@ -3,7 +3,7 @@ require "language_pack/base"
 
 class LanguagePack::NoLockfile < LanguagePack::Base
   def self.use?
-    !File.exists?("Gemfile.lock")
+    !File.exists?("Gemfile.lock") && !File.exists?("gems.locked")
   end
 
   def name
@@ -11,6 +11,6 @@ class LanguagePack::NoLockfile < LanguagePack::Base
   end
 
   def compile
-    error "Gemfile.lock required. Please check it in."
+    error "Gemfile.lock or gems.locked required. Please check it in."
   end
 end

--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -167,7 +167,7 @@ WARNING
       plugins.each do |plugin, gem|
         warn "Injecting plugin '#{plugin}'"
       end
-      warn "Add 'rails_12factor' gem to your Gemfile to skip plugin injection"
+      warn "Add 'rails_12factor' gem to your #{bundler.gemfile} to skip plugin injection"
       LanguagePack::Helpers::PluginsInstaller.new(plugins.keys).install
     end
   end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -23,16 +23,8 @@ class LanguagePack::Ruby < LanguagePack::Base
   # @return [Boolean] true if it's a Ruby app
   def self.use?
     instrument "ruby.use" do
-      File.exist?("Gemfile")
+      File.exist?(bundler.gemfile)
     end
-  end
-
-  def self.bundler
-    @@bundler ||= LanguagePack::Helpers::BundlerWrapper.new.install
-  end
-
-  def bundler
-    self.class.bundler
   end
 
   def initialize(build_path, cache_path=nil)
@@ -529,8 +521,8 @@ SHELL
       topic "Using Ruby version: #{ruby_version.version_for_download}"
       if !ruby_version.set
         warn(<<-WARNING)
-You have not declared a Ruby version in your Gemfile.
-To set your Ruby version add this line to your Gemfile:
+You have not declared a Ruby version in your #{bundler.gemfile}.
+To set your Ruby version add this line to your #{bundler.gemfile}:
 #{ruby_version.to_gemfile}
 # See https://devcenter.heroku.com/articles/ruby-versions for more information.
 WARNING
@@ -800,9 +792,9 @@ https://devcenter.heroku.com/articles/bundler-configuration
 WARNING
         end
 
-        if bundler.windows_gemfile_lock?
+        if bundler.windows_lockfile?
           warn(<<-WARNING, inline: true)
-Removing `Gemfile.lock` because it was generated on Windows.
+Removing `#{bundler.lockfile}` because it was generated on Windows.
 Bundler will do a full resolve so native gems are handled properly.
 This may result in unexpected gem versions being used in your app.
 In rare occasions Bundler may not be able to resolve your dependencies at all.
@@ -810,7 +802,7 @@ https://devcenter.heroku.com/articles/bundler-windows-gemfile
 WARNING
 
           log("bundle", "has_windows_gemfile_lock")
-          File.unlink("Gemfile.lock")
+          File.unlink(bundler.lockfile)
         else
           # using --deployment is preferred if we can
           bundle_command += " --deployment"
@@ -834,7 +826,7 @@ WARNING
 
           # we need to set BUNDLE_CONFIG and BUNDLE_GEMFILE for
           # codon since it uses bundler.
-         env_vars["BUNDLE_GEMFILE"] = "#{pwd}/Gemfile"
+          env_vars["BUNDLE_GEMFILE"] = bundler.gemfile_path.realpath.to_s
           env_vars["BUNDLE_CONFIG"] = "#{pwd}/.bundle/config"
           env_vars["CPATH"] = noshellescape("#{yaml_include}:$CPATH")
           env_vars["CPPATH"] = noshellescape("#{yaml_include}:$CPPATH")
@@ -884,16 +876,16 @@ https://devcenter.heroku.com/articles/sqlite3
             ERROR
           end
 
-          if bundler_output.match(/but your Gemfile specified/)
+          if bundler_output.match(/but your #{bundler.gemfile} specified/)
             mcount "fail.ruby_version_mismatch"
             error_message += <<-ERROR
 
 Detected a mismatch between your Ruby version installed and
-Ruby version specified in Gemfile or Gemfile.lock. You can
+Ruby version specified in #{bundler.gemfile} or #{bundler.lockfile}. You can
 correct this by running:
 
     $ bundle update --ruby
-    $ git add Gemfile.lock
+    $ git add #{bundler.lockfile}
     $ git commit -m "update ruby version"
 
 If this does not solve the issue please see this documentation:
@@ -1007,7 +999,7 @@ params = CGI.parse(uri.query || "")
       raise_on_fail      = bundler.gem_version('railties') && bundler.gem_version('railties') > Gem::Version.new('3.x')
 
       topic "Detecting rake tasks"
-      rake = LanguagePack::Helpers::RakeRunner.new(rake_gem_available)
+      rake = LanguagePack::Helpers::RakeRunner.new(rake_gem_available, bundler.gemfile)
       rake.load_rake_tasks!({ env: rake_env }, raise_on_fail)
       rake
     end

--- a/spec/hatchet/bundler_spec.rb
+++ b/spec/hatchet/bundler_spec.rb
@@ -15,4 +15,26 @@ describe "Bundler" do
       app.push!
     end
   end
+
+  it "deploys with gems.rb" do
+    before_deploy = Proc.new do
+      run!(%Q{mv Gemfile gems.rb})
+      run!(%Q{mv Gemfile.lock gems.locked})
+    end
+
+    Hatchet::Runner.new("default_ruby", before_deploy: before_deploy).deploy do |app|
+      expect(app.output).to match("Using gems.rb and gems.locked for Bundler")
+    end
+  end
+
+  it "does not deploy with both Gemfile and gems.rb" do
+    before_deploy = Proc.new do
+      run!(%Q{cp Gemfile gems.rb})
+    end
+
+    Hatchet::Runner.new("default_ruby", allow_failure: true, before_deploy: before_deploy).deploy do |app|
+      expect(app.output).to match("You have both a Gemfile and a gems.rb in your repository.")
+      expect(app).not_to be_deployed
+    end
+  end
 end

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -103,6 +103,36 @@ describe "Ruby apps" do
       end
     end
   end
+
+  describe '.bundle/config detection' do
+    context 'BUNDLE_GEMS__CONTRIBSYS__COM is set' do
+      context '.bundle/config is not checked in' do
+        it "doesn't warn about .bundle/config" do
+          before_deploy = proc do
+            run! 'rm -rf .bundle'
+          end
+          config = { 'BUNDLE_GEMS__CONTRIBSYS__COM' => 'foo:bar' }
+
+          Hatchet::Runner.new('default_ruby', config: config, before_deploy: before_deploy).deploy do |app|
+            expect(app.output).not_to include('You have the `.bundle/config` file checked into your repository')
+          end
+        end
+      end
+
+      context '.bundle/config is checked in' do
+        it 'warns about .bundle/config' do
+          before_deploy = proc do
+            run! "mkdir -p .bundle && echo '---' > .bundle/config"
+          end
+          config = { 'BUNDLE_GEMS__CONTRIBSYS__COM' => 'foo:bar' }
+
+          Hatchet::Runner.new('default_ruby', config: config, before_deploy: before_deploy).deploy do |app|
+            expect(app.output).to include('You have the `.bundle/config` file checked into your repository')
+          end
+        end
+      end
+    end
+  end
 end
 
 describe "Raise errors on specific gems" do

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -122,7 +122,7 @@ describe "No Lockfile" do
   it "should not deploy" do
     Hatchet::Runner.new("no_lockfile", allow_failure: true).deploy do |app|
       expect(app).not_to be_deployed
-      expect(app.output).to include("Gemfile.lock required")
+      expect(app.output).to include("Gemfile.lock or gems.locked required")
     end
   end
 end

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -20,14 +20,14 @@ describe "BundlerWrapper" do
   end
 
   it "handles windows BUNDLED WITH" do
-    wrapper = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: fixture_path("windows_lockfile/Gemfile"))
+    wrapper = LanguagePack::Helpers::BundlerWrapper.new(build_dir: fixture_path("windows_lockfile"))
 
     expect(wrapper.version).to eq(LanguagePack::Helpers::BundlerWrapper::BLESSED_BUNDLER_VERSIONS["2"])
   end
 
   it "detects windows gemfiles" do
     Hatchet::App.new("rails4_windows_mri193").in_directory_fork do |dir|
-      expect(@bundler.install.windows_gemfile_lock?).to be_truthy
+      expect(@bundler.install.windows_lockfile?).to be_truthy
     end
   end
 

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -127,7 +127,7 @@ describe "RubyVersion" do
     bundle_error_msg = "Zomg der was a problem in da gemfile"
     error_klass      = LanguagePack::Helpers::BundlerWrapper::GemfileParseError
     Hatchet::App.new("bad_gemfile_on_platform").in_directory_fork do |dir|
-      @bundler       = LanguagePack::Helpers::BundlerWrapper.new().install
+      @bundler       = LanguagePack::Helpers::BundlerWrapper.new.install
       expect { LanguagePack::RubyVersion.new(@bundler.ruby_version) }.to raise_error(error_klass, /#{Regexp.escape(bundle_error_msg)}/)
     end
   end


### PR DESCRIPTION
### Add support for gems.rb

On the surface, this adds support for gems.rb and gems.locked (instead of Gemfile and Gemfile.lock). It also allows other buildpacks to use the Ruby buildpack via subclassing and override the paths to arbitrary values easily, which is important in the case of Kajabi/heroku-buildpack-bootboot.

### Check for .bundle/config before running bundle

If there are any user set bundle environment variables (like gem credentials), these will be persisted in .bundle/config automatically, so we need to check for .bundle/config before any bundle commands have been run otherwise it will report a false positive.